### PR TITLE
Add admin dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,68 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Admin Dashboard - Clothing Store</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <!-- <h1>Welcome to testing</h1> -->
-    <h2>Frontend Developmen</h2>
+    <nav class="navbar navbar-dark bg-dark">
+        <div class="container-fluid">
+            <span class="navbar-brand mb-0 h1">Clothing Admin</span>
+        </div>
+    </nav>
+    <div class="container-fluid">
+        <div class="row">
+            <nav class="col-md-2 d-none d-md-block bg-light sidebar">
+                <div class="position-sticky pt-3">
+                    <ul class="nav flex-column">
+                        <li class="nav-item">
+                            <a class="nav-link active" href="#">Dashboard</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="#">Orders</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="#">Products</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="#">Customers</a>
+                        </li>
+                    </ul>
+                </div>
+            </nav>
+            <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
+                <h1 class="mt-4">Dashboard</h1>
+                <div class="row my-3">
+                    <div class="col-lg-3 col-md-6 mb-3">
+                        <div class="card text-center">
+                            <div class="card-body">
+                                <h5 class="card-title">Total Orders</h5>
+                                <p class="card-text" id="totalOrders">0</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-3 col-md-6 mb-3">
+                        <div class="card text-center">
+                            <div class="card-body">
+                                <h5 class="card-title">Products</h5>
+                                <p class="card-text" id="totalProducts">0</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-3 col-md-6 mb-3">
+                        <div class="card text-center">
+                            <div class="card-body">
+                                <h5 class="card-title">Customers</h5>
+                                <p class="card-text" id="totalCustomers">0</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </main>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,5 @@
+document.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('totalOrders').textContent = '120';
+    document.getElementById('totalProducts').textContent = '48';
+    document.getElementById('totalCustomers').textContent = '75';
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,11 @@
+body {
+    font-family: Arial, sans-serif;
+}
+
+.sidebar {
+    height: calc(100vh - 56px);
+}
+
+.card-text {
+    font-size: 2rem;
+}


### PR DESCRIPTION
## Summary
- replace placeholder page with a Bootstrap-powered admin dashboard
- style layout and metrics with custom CSS
- add small JavaScript snippet to populate example stats

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686db3fbf1bc832ab392edf264e8d4ec